### PR TITLE
[JENKINS-25977] Upgrading to core 1.596.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.1</version>
+    <version>1.596.1</version>
   </parent>
 
   <groupId>org.jvnet.hudson.plugins</groupId>


### PR DESCRIPTION
Upgrading to core 1.596.1 because we are facing a known issue (cyclic dependencies on plugins) in 1.580.1 (see [this article](https://cloudbees.zendesk.com/hc/en-us/articles/204170674-After-updating-Git-Plugin-Jenkins-fails-to-restart-))