### PR TITLE
Cleanup Maven Plugin upper bounds management hacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.33</version>
+    <version>2.35</version>
     <relativePath />
   </parent>
 
@@ -26,8 +26,9 @@
     <mockito.version>1.10.8</mockito.version>
     <dashboard-view.version>2.9.4</dashboard-view.version>
     <token-macro.version>2.1</token-macro.version>
-    <jenkins-maven-plugin.version>2.17</jenkins-maven-plugin.version>
+    <jenkins-maven-plugin.version>2.18-20170921.112418-3</jenkins-maven-plugin.version>
     <matrix-project.version>1.7.1</matrix-project.version>
+    <junit-plugin.version>1.6</junit-plugin.version>
 
     <!-- Maven plug-in versions -->
     <maven-cobertura-plugin.version>2.6</maven-cobertura-plugin.version>
@@ -84,6 +85,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit-plugin.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
       <version>${dashboard-view.version}</version>
       <optional>true</optional>
@@ -103,35 +109,6 @@
   </dependencies>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <rules>
-            <requireUpperBoundDeps>
-              <excludes combine.children="append">
-                <!-- All of these are required as maven-plugin has
-                     a lot of inconsistent transitive dependencies -->
-                <exclude>org.apache.ant:ant</exclude>
-                <exclude>org.apache.httpcomponents:httpclient</exclude>
-                <exclude>org.apache.httpcomponents:httpcore</exclude>
-                <exclude>org.apache.maven:maven-aether-provider</exclude>
-                <exclude>org.apache.maven:maven-core</exclude>
-                <exclude>org.apache.maven:maven-embedder</exclude>
-                <exclude>org.codehaus.plexus:plexus-classworlds</exclude>
-                <exclude>org.codehaus.plexus:plexus-utils</exclude>
-                <exclude>org.jenkins-ci.plugins:junit</exclude>
-                <exclude>org.jenkins-ci.plugins:mailer</exclude>
-                <exclude>org.jenkins-ci.modules:instance-identity</exclude>
-                <exclude>org.jenkins-ci.modules:ssh-cli-auth</exclude>
-                <exclude>commons-io:commons-io</exclude>
-              </excludes>
-            </requireUpperBoundDeps>
-          </rules>
-        </configuration>
-      </plugin>
-    </plugins>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <mockito.version>1.10.8</mockito.version>
     <dashboard-view.version>2.9.4</dashboard-view.version>
     <token-macro.version>2.1</token-macro.version>
-    <jenkins-maven-plugin.version>2.18-20170921.112418-3</jenkins-maven-plugin.version>
+    <jenkins-maven-plugin.version>3.0</jenkins-maven-plugin.version>
     <matrix-project.version>1.7.1</matrix-project.version>
     <junit-plugin.version>1.6</junit-plugin.version>
 


### PR DESCRIPTION
It is a downstream PR of https://github.com/jenkinsci/maven-plugin/pull/102, which demonstrates the cleanup of the dependency mess reported by @jtnord in [JENKINS-45271](https://issues.jenkins-ci.org/browse/JENKINS-45271)

@orrc @uhafner @reviewbybees 