### PR TITLE
Use spotbugs from bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
   </description>
 
   <properties>
-    <jenkins.baseline>2.249</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.2</jenkins.version>
+    <jenkins.baseline>2.204</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.6</jenkins.version>
     <java.level>8</java.level>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>1.6.0</codingstyle.config.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.9</version>
+    <version>4.10</version>
     <relativePath />
   </parent>
 
@@ -22,15 +22,14 @@
   </description>
 
   <properties>
-    <jenkins.baseline>2.204</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.6</jenkins.version>
+    <jenkins.baseline>2.249</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.2</jenkins.version>
     <java.level>8</java.level>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>1.6.0</codingstyle.config.version>
 
     <!-- Library Dependencies Versions -->
     <error-prone.version>2.4.0</error-prone.version>
-    <spotbugs.annotations>4.1.3</spotbugs.annotations>
     <slf4j.version>1.7.30</slf4j.version>
 
     <!-- Test Library Dependencies Versions -->
@@ -46,7 +45,6 @@
     <pmd.version>6.28.0</pmd.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <checkstyle.version>8.36.2</checkstyle.version>
-    <spotbugs-maven-plugin.version>4.1.3</spotbugs-maven-plugin.version>
     <findsecbugs-plugin.version>1.10.1</findsecbugs-plugin.version>
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     <maven-surefire.plugin>3.0.0-M4</maven-surefire.plugin>
@@ -120,11 +118,6 @@
   <dependencies>
 
     <!-- Project Dependencies -->
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <version>${spotbugs.annotations}</version>
-    </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
@@ -413,7 +406,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${spotbugs-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>run-spotbugs</id>


### PR DESCRIPTION
$ mvn dependency:tree | grep spotbugs
[INFO] +- com.github.spotbugs:spotbugs-annotations:jar:4.0.3:provided (optional)

One of the PRs required for https://github.com/jenkinsci/bom/pull/322

Pulls in https://github.com/jenkinsci/jenkins/pull/4689 which bumps spotbugs to 4.x

First LTS with it in is 2.249.1

Tested with bootstrap api plugin, no upper bounds issues