### PR TITLE
Remove commons-io as it comes from Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
         <type>pom</type>
       </dependency>
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
         <version>2.2</version>
@@ -358,6 +353,7 @@
             <artifactId>codingstyle</artifactId>
             <version>${codingstyle.config.version}</version>
             <classifier>config</classifier>
+
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Part of fixing https://github.com/jenkinsci/junit-plugin/pull/176

https://github.com/jenkinsci/jenkins/blob/dd134ef84e642e851c1fcc8946bebef5cce840ca/bom/pom.xml#L69

Tested in bootstrap4-api-plugin, the Jenkins bom overrides the version coming from codingstyle but not the explicit dependency here.