### PR TITLE
Bump version of Jenkins baseline to LTS 2.289.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Analysis POM
 
 [![Join the chat at https://gitter.im/jenkinsci/warnings-plugin](https://badges.gitter.im/jenkinsci/warnings-plugin.svg)](https://gitter.im/jenkinsci/warnings-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Jenkins Version](https://img.shields.io/badge/Jenkins-2.263.1-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
+[![Jenkins Version](https://img.shields.io/badge/Jenkins-2.289.1-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
 [![Jenkins](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/master/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/master/)
 [![GitHub Actions](https://github.com/jenkinsci/analysis-pom-plugin/workflows/GitHub%20CI/badge.svg?branch=master)](https://github.com/jenkinsci/analysis-pom-plugin/actions)
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
   </description>
 
   <properties>
-    <jenkins.baseline>2.277</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.289</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <java.level>8</java.level>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>2.10.0</codingstyle.config.version>


### PR DESCRIPTION
See https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/