### PR TITLE
Switch baseline of Jenkins to LTS 2.319.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
   </description>
 
   <properties>
-    <jenkins.baseline>2.289</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.319</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <java.level>8</java.level>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>2.22.0</codingstyle.config.version>


### PR DESCRIPTION
From now on we use .3 as patch release.

See https://github.com/jenkins-infra/jenkins.io/pull/4876
