### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <jenkins.baseline>2.319</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <java.level>8</java.level>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>2.25.0</codingstyle.config.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,6 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>${java.level}</source>
-          <target>${java.level}</target>
-          <testSource>${java.level}</testSource>
-          <testTarget>${java.level}</testTarget>
           <compilerArgs>
             <arg>-Xlint:all</arg>
           </compilerArgs>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.