### PR TITLE
Use JUnit BOM to simplify version constraints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.10.1</equalsverifier.version>
     <junit.version>5.9.1</junit.version>
-    <junit-platform-launcher.version>1.9.1</junit-platform-launcher.version>
     <junit-pioneer.version>1.7.1</junit-pioneer.version>
     <mockito.version>4.8.0</mockito.version>
     <assertj.version>3.23.1</assertj.version>
@@ -89,6 +88,13 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>1.12.17</version>
@@ -108,31 +114,26 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>${junit-platform-launcher.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Otherwise we get test failures like in https://github.com/jenkinsci/warnings-ng-plugin/pull/1372.