### PR TITLE
Add dependencies of commons-lang and commons-text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,15 @@
   </dependencyManagement>
 
   <dependencies>
+    <!-- Project Dependencies -->
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-text-api</artifactId>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>


### PR DESCRIPTION
These dependencies have been provided by plugin-utils-api for quite some time, but it makes more sense to add an explicit dependency here.

Required by https://github.com/jenkinsci/plugin-util-api-plugin/pull/217