### PR TITLE
Upgrade baseline to 2.361.x and JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,11 +101,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy</artifactId>
-        <version>1.12.19</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>analysis-pom</artifactId>
   <packaging>pom</packaging>
   <name>Analysis Plug-ins Parent POM</name>
-  <version>5.38.0-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
 
   <url>https://github.com/jenkinsci/analysis-pom-plugin</url>
   <description>This static analysis POM serves as parent POM for all my Jenkins Plugins. It basically enhances the
@@ -23,10 +23,10 @@
   </description>
 
   <properties>
-    <jenkins.baseline>2.346</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.361</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
-    <codingstyle.config.version>2.25.0</codingstyle.config.version>
+    <codingstyle.config.version>3.8.0</codingstyle.config.version>
 
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.12.3</equalsverifier.version>


### PR DESCRIPTION
Set Jenkins baseline to 2.361.x. This also changes the JDK baseline to 11.