### PR TITLE
Switch baseline to 2.387.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <jenkins.baseline>2.387</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>3.17.0</codingstyle.config.version>
 


### PR DESCRIPTION
Set recommend version due to https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/.