### PR TITLE
Remove duplicate code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.69</version>
+    <version>4.73</version>
     <relativePath />
   </parent>
 
@@ -30,36 +30,24 @@
 
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.14.3</equalsverifier.version>
-    <junit.version>5.9.3</junit.version>
     <junit-pioneer.version>2.0.1</junit-pioneer.version>
-    <mockito.version>5.4.0</mockito.version>
     <assertj.version>3.24.2</assertj.version>
     <archunit.version>1.0.1</archunit.version>
     <json-unit-fluent.version>2.38.0</json-unit-fluent.version>
 
     <!-- Maven plug-in versions -->
-    <spotbugs-maven-plugin.version>4.7.3.5</spotbugs-maven-plugin.version>
     <spotbugs.version>4.7.3</spotbugs.version>
     <pmd.version>6.55.0</pmd.version>
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <checkstyle.version>10.12.1</checkstyle.version>
     <maven-pmd-plugin.version>3.21.0</maven-pmd-plugin.version>
     <findsecbugs-plugin.version>1.12.0</findsecbugs-plugin.version>
-    <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
-    <maven-surefire.plugin>3.1.0</maven-surefire.plugin>
-    <maven-failsafe.plugin>3.1.2</maven-failsafe.plugin>
-    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-    <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
-    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <pitest-maven.plugin>1.14.2</pitest-maven.plugin>
     <pitest-maven.junit5.plugin>1.2.0</pitest-maven.junit5.plugin>
     <revapi-maven-plugin.version>0.15.0</revapi-maven-plugin.version>
     <revapi-java.version>0.28.1</revapi-java.version>
     <revapi-reporter-json-version>0.5.0</revapi-reporter-json-version>
     <assertj-assertions-generator-maven-plugin.version>2.2.0</assertj-assertions-generator-maven-plugin.version>
-    <animal-sniffer-maven-plugin.version>1.18</animal-sniffer-maven-plugin.version>
-    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
 
   </properties>
 
@@ -86,20 +74,6 @@
         <version>2198.v39c76fc308ca</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${junit.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-bom</artifactId>
-        <version>${mockito.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
@@ -193,7 +167,9 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin.version}</version>
         <executions>
           <execution>
             <id>display-info</id>
@@ -216,7 +192,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
@@ -226,6 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -249,8 +228,9 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire.plugin}</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1798 -->
           <excludes>
@@ -267,8 +247,9 @@
         </dependencies>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-failsafe.plugin}</version>
+        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <includes>
             <include>**/*ITest.*</include>
@@ -286,6 +267,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${maven-enforcer-plugin.version}</version>
         <executions>
           <execution>
             <id>display-info</id>
@@ -186,7 +185,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>${maven-release-plugin.version}</version>
         <configuration>
           <tagNameFormat>v@{project.version}</tagNameFormat>
         </configuration>
@@ -194,7 +192,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
@@ -204,7 +201,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -230,7 +226,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace> <!-- SUREFIRE-1798 -->
           <excludes>
@@ -269,7 +264,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
         <configuration>
           <additionalOptions>-Xdoclint:all</additionalOptions>
           <failOnWarnings>false</failOnWarnings>
@@ -400,7 +394,6 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${spotbugs-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>run-spotbugs</id>
@@ -448,7 +441,6 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
         <configuration>
           <includes>
             <include>io/jenkins/plugins/**/*</include>


### PR DESCRIPTION
As of the latest plugin parent POM, the properties are already defined in the plugin parent POM and the BOMs are already imported, so these code is duplicate and can be safely deleted.