### PR TITLE
Define proper NPM and node versions for frontend-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>3.19.0</codingstyle.config.version>
 
+    <!-- NPM and node versions for frontend-maven-plugin -->
+    <node.version>18.17.1</node.version>
+    <npm.version>9.8.1</npm.version>
+
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.15.1</equalsverifier.version>
     <junit-pioneer.version>2.1.0</junit-pioneer.version>


### PR DESCRIPTION
These properties are undefined in the parent pom. It makes sense to use the same default for all plugins.