### PR TITLE
Update CI actions to use Java 17 and 21 with Maven 3.9.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [17]
-        include:
-          - platform: ubuntu-latest
-            jdk: 11
-          - platform: macos-latest
-            jdk: 11
+        jdk: [17, 21]
 
     runs-on: ${{ matrix.platform }}
     name: on ${{ matrix.platform }} with JDK ${{ matrix.jdk }}
@@ -32,6 +27,10 @@ jobs:
           java-version: '${{ matrix.jdk }}'
           check-latest: true
           cache: 'maven'
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.9.5
       - name: Build with Maven
         env:
           BROWSER: chrome-container

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Join the chat at https://gitter.im/jenkinsci/warnings-plugin](https://badges.gitter.im/jenkinsci/warnings-plugin.svg)](https://gitter.im/jenkinsci/warnings-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Jenkins Version](https://img.shields.io/badge/Jenkins-2.387.3-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
-[![Jenkins](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/master/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/master/)
-[![GitHub Actions](https://github.com/jenkinsci/analysis-pom-plugin/workflows/GitHub%20CI/badge.svg?branch=master)](https://github.com/jenkinsci/analysis-pom-plugin/actions)
+[![Jenkins](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/main/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/main/)
+[![GitHub Actions](https://github.com/jenkinsci/analysis-pom-plugin/workflows/GitHub%20CI/badge.svg?branch=main)](https://github.com/jenkinsci/analysis-pom-plugin/actions)
 
 This static analysis POM serves as parent POM for all my Jenkins Plugins. It basically enhances the 
 [Parent POM for Jenkins Plugins](https://github.com/jenkinsci/plugin-pom) 


### PR DESCRIPTION
[Switch builds environment matrix to Java 17 and 21 and custom Maven.](https://github.com/jenkinsci/analysis-pom-plugin/commit/b6031a2e8586475a10a9a5b8c41a67c1ef653157).