### PR TITLE
Use parent pom requireUpperBoundDeps configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,22 +172,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>display-info</id>
-            <configuration>
-              <rules>
-                <requireUpperBoundDeps>
-                  <level>WARN</level>
-                </requireUpperBoundDeps>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <configuration>
           <tagNameFormat>v@{project.version}</tagNameFormat>


### PR DESCRIPTION
## Use parent pom `requireUpperBoundDeps` configuration

https://github.com/jenkinsci/bom/pull/2680 notes that with `requireUpperBoundDeps.level=WARN` we miss cases where upper bounds checks could have detected an issue earlier.

Let's switch to use the `requireUpperBoundDeps` configuration provided by the parent pom.

### Testing done

I confirmed that `mvn help:effective-pom` before this change includes the `<level>WARN</level>`.

After this change it does not include `<level>WARN</level>` but does include the other settings for `requireUpperBoundDeps`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
