### PR TITLE
Set the version of `org.junit.platform` to 1.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
     <revapi-java.version>0.28.1</revapi-java.version>
     <revapi-reporter-json-version>0.5.0</revapi-reporter-json-version>
     <assertj-assertions-generator-maven-plugin.version>2.2.0</assertj-assertions-generator-maven-plugin.version>
-
   </properties>
 
   <licenses>
@@ -83,6 +82,21 @@
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>1.14.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>1.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-commons</artifactId>
+        <version>1.10.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Add some version constraints so that the old enforcer 3.2.1. that is used in Jenkins maven-hpi plugin does not complain anymore. See https://github.com/jenkinsci/maven-hpi-plugin/pull/391 for details.

Fixes https://issues.jenkins.io/browse/JENKINS-72392.