### PR TITLE
Prepare for new baseline Jenkins 2.426.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Analysis POM
 
 [![Join the chat at https://gitter.im/jenkinsci/warnings-plugin](https://badges.gitter.im/jenkinsci/warnings-plugin.svg)](https://gitter.im/jenkinsci/warnings-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Jenkins Version](https://img.shields.io/badge/Jenkins-2.387.3-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
+[![Jenkins Version](https://img.shields.io/badge/Jenkins-2.426.3-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
 [![Jenkins](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/main/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/main/)
 [![GitHub Actions](https://github.com/jenkinsci/analysis-pom-plugin/workflows/GitHub%20CI/badge.svg)](https://github.com/jenkinsci/analysis-pom-plugin/actions)
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>analysis-pom</artifactId>
   <packaging>pom</packaging>
   <name>Analysis Plug-ins Parent POM</name>
-  <version>6.18.0-SNAPSHOT</version>
+  <version>7.0.0-SNAPSHOT</version>
 
   <url>https://github.com/jenkinsci/analysis-pom-plugin</url>
   <description>This static analysis POM serves as parent POM for all my Jenkins Plugins. It basically enhances the
@@ -23,14 +23,14 @@
   </description>
 
   <properties>
-    <jenkins.baseline>2.387</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.426</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.2</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>3.32.0</codingstyle.config.version>
 
     <!-- NPM and node versions for frontend-maven-plugin -->
-    <node.version>18.17.1</node.version>
-    <npm.version>9.8.1</npm.version>
+    <node.version>20.11.0</node.version>
+    <npm.version>10.3.0</npm.version>
 
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.15.6</equalsverifier.version>
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <version>2718.v7e8a_d43b_3f0b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <jenkins.baseline>2.426</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.2</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>3.32.0</codingstyle.config.version>
 
@@ -52,6 +52,8 @@
     <revapi-java.version>0.28.1</revapi-java.version>
     <revapi-reporter-json-version>0.5.0</revapi-reporter-json-version>
     <assertj-assertions-generator-maven-plugin.version>2.2.0</assertj-assertions-generator-maven-plugin.version>
+
+    <jenkins-test-harness.version>2152.v60323ca_97732</jenkins-test-harness.version>
   </properties>
 
   <licenses>
@@ -74,7 +76,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>2718.v7e8a_d43b_3f0b_</version>
+        <version>2746.vb_79a_1d3e7b_c8</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Switch Jenkins baseline to 2.426.3.

Tasks:
- [x] Bump minor version from 2. to .3 when Jenkins 2.426.3 has been released