### PR TITLE
Fail build on CheckStyle or PMD violations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <pmd.version>7.0.0</pmd.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
     <checkstyle.version>10.15.0</checkstyle.version>
-    <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
+    <maven-pmd-plugin.version>3.22.0</maven-pmd-plugin.version>
     <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
     <pitest-maven.plugin>1.16.0</pitest-maven.plugin>
     <pitest-maven.junit5.plugin>1.2.1</pitest-maven.junit5.plugin>
@@ -334,7 +334,7 @@
         <configuration>
           <linkXRef>false</linkXRef>
           <excludeGeneratedSources>true</excludeGeneratedSources>
-          <failsOnError>false</failsOnError>
+          <violationSeverity>warning</violationSeverity>
           <excludes>**/*Assert*.java,**/InjectedTest.java,**/Messages.java,**/*_jmh*</excludes>
         </configuration>
         <dependencies>
@@ -354,7 +354,7 @@
           <execution>
             <id>run-checkstyle-java</id>
             <goals>
-              <goal>checkstyle</goal>
+              <goal>check</goal>
             </goals>
             <phase>verify</phase>
             <configuration>
@@ -367,7 +367,7 @@
           <execution>
             <id>run-checkstyle-tests</id>
             <goals>
-              <goal>checkstyle</goal>
+              <goal>check</goal>
             </goals>
             <phase>verify</phase>
             <configuration>
@@ -375,6 +375,7 @@
               <includeTestSourceDirectory>true</includeTestSourceDirectory>
               <configLocation>checkstyle-tests-configuration.xml</configLocation>
               <outputFile>${project.build.directory}/checkstyle-tests/checkstyle-result.xml</outputFile>
+              <sourceDirectories></sourceDirectories>
             </configuration>
           </execution>
         </executions>
@@ -386,13 +387,9 @@
         <configuration>
           <linkXRef>false</linkXRef>
           <failOnViolation>false</failOnViolation>
+          <targetJdk>${java.version}</targetJdk>
         </configuration>
         <dependencies>
-          <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-compat6</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
           <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
@@ -409,11 +406,6 @@
             <version>${pmd.version}</version>
           </dependency>
           <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-jsp</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
-          <dependency>
             <groupId>edu.hm.hafner</groupId>
             <artifactId>codingstyle</artifactId>
             <version>${codingstyle.config.version}</version>
@@ -425,6 +417,7 @@
             <id>run-pmd-java</id>
             <goals>
               <goal>pmd</goal>
+              <goal>check</goal>
               <goal>cpd</goal>
             </goals>
             <phase>verify</phase>
@@ -441,6 +434,7 @@
             <id>run-pmd-tests</id>
             <goals>
               <goal>pmd</goal>
+              <goal>check</goal>
               <goal>cpd</goal>
             </goals>
             <phase>verify</phase>
@@ -462,6 +456,7 @@
             <id>run-pmd-javascript</id>
             <goals>
               <goal>pmd</goal>
+              <goal>check</goal>
             </goals>
             <phase>verify</phase>
             <configuration>
@@ -480,7 +475,6 @@
               </includes>
             </configuration>
           </execution>
-
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
To see all CheckStyle and PMD violations in a maven build you need to run maven with option 
`-Dcheckstyle.failOnViolation=false` and `-Dpmd.failOnViolation=false`.

Supersedes #483 