### PR TITLE
Bump node and NPM to latest LTS versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,8 @@
     <!-- NPM and node versions for frontend-maven-plugin -->
     <node.version>20.13.1</node.version>
     <npm.version>10.8.0</npm.version>
+    <nodeDownloadRoot>https://nodejs.org/dist/</nodeDownloadRoot>
+    <npmDownloadRoot>https://registry.npmjs.org/npm/-/</npmDownloadRoot>
 
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.16.1</equalsverifier.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
     <pmd.skip>false</pmd.skip>
 
     <!-- NPM and node versions for frontend-maven-plugin -->
-    <node.version>20.11.0</node.version>
-    <npm.version>10.3.0</npm.version>
+    <node.version>20.13.1</node.version>
+    <npm.version>10.8.0</npm.version>
 
     <!-- Test Library Dependencies Versions -->
     <equalsverifier.version>3.16.1</equalsverifier.version>


### PR DESCRIPTION
New configuration:

```
    <node.version>20.13.1</node.version>
    <npm.version>10.8.0</npm.version>
    <nodeDownloadRoot>https://nodejs.org/dist/</nodeDownloadRoot>
    <npmDownloadRoot>https://registry.npmjs.org/npm/-/</npmDownloadRoot>
```