### PR TITLE
Revert skipping of maven flatten plugin to reenable incrementals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -752,7 +752,6 @@
         <checkstyle.failOnViolation>false</checkstyle.failOnViolation>
         <pmd.failOnViolation>false</pmd.failOnViolation>
         <spotbugs.failOnError>false</spotbugs.failOnError>
-        <flatten.flatten.skip>true</flatten.flatten.skip>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
```
12:50:52  HttpMethod: POST
[1](https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/pipeline-console/?start-byte=0&selected-node=169#log-1)2:50:52  URL: https://incrementals.jenkins.io/
1[2](https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/pipeline-console/?start-byte=0&selected-node=169#log-2):50:52  Content-Type: application/json
12:50:52  Authorization: *****
12:50:52  Sending request to url: https://incrementals.jenkins.io/
12:50:52  Response Code: HTTP/1.1 [4](https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/pipeline-console/?start-byte=0&selected-node=169#log-4)00 Bad Request
12:50:52  Response: 
12:[5](https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/pipeline-console/?start-byte=0&selected-node=169#log-5)0:52  Invalid archive retrieved from Jenkins, perhaps the plugin is not properly incrementalized?
12:50:52  Error: ZIP error: Error: Wrong commit hash in /project/scm/tag, expected [6](https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/pipeline-console/?start-byte=0&selected-node=169#log-6)2dd50b180ee2f50faf1d9cea8965e60dd6ea19b, got ${scmTag} from https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/artifact/**/*62dd50b*1[8](https://ci.jenkins.io/job/Plugins/job/prism-api-plugin/job/PR-165/4/pipeline-console/?start-byte=0&selected-node=169#log-8)0ee*/*62dd50b*180ee*/*zip*/archive.zip
12:50:52  Success: Status code 400 is in the accepted range: 100:599
```