### PR TITLE
Use new Jenkins baseline 2.462 that hides ASM dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Analysis POM
 
 [![Join the chat at https://gitter.im/jenkinsci/warnings-plugin](https://badges.gitter.im/jenkinsci/warnings-plugin.svg)](https://gitter.im/jenkinsci/warnings-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Jenkins Version](https://img.shields.io/badge/Jenkins-2.426.3-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
+[![Jenkins Version](https://img.shields.io/badge/Jenkins-2.462.2-green.svg?label=min.%20Jenkins)](https://jenkins.io/download/)
 [![Jenkins](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/main/badge/icon?subject=Jenkins%20CI)](https://ci.jenkins.io/job/Plugins/job/analysis-pom-plugin/job/main/)
 [![GitHub Actions](https://github.com/jenkinsci/analysis-pom-plugin/workflows/GitHub%20CI/badge.svg)](https://github.com/jenkinsci/analysis-pom-plugin/actions)
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.jvnet.hudson.plugins</groupId>
   <artifactId>analysis-pom</artifactId>
-  <version>8.8.0-SNAPSHOT</version>
+  <version>9.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Analysis Plug-ins Parent POM</name>
   <description>This static analysis POM serves as parent POM for all my Jenkins Plugins. It basically enhances the
@@ -45,8 +45,8 @@
   </scm>
 
   <properties>
-    <jenkins.baseline>2.426</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.462</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <java.version>${maven.compiler.release}</java.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <codingstyle.config.version>4.13.0</codingstyle.config.version>
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3208.vb_21177d4b_cd9</version>
+        <version>3358.vea_fa_1f41504d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Required to fix [JENKINS-73776](https://issues.jenkins.io/browse/JENKINS-73776).