### PR TITLE
Add the missing version for OWASP dependency check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <revapi-reporter-json-version>0.5.0</revapi-reporter-json-version>
     <assertj-assertions-generator-maven-plugin.version>2.2.0</assertj-assertions-generator-maven-plugin.version>
     <depgraph-maven-plugin.version>4.0.3</depgraph-maven-plugin.version>
+    <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
 
     <!-- OpenRewrite versions   -->
     <rewrite-maven-plugin.version>6.1.4</rewrite-maven-plugin.version>


### PR DESCRIPTION
Add version 12.1.0 as property `dependency-check-maven.version`.
