### PR TITLE
Ignore SpotBugs annotations in RevApi checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -745,10 +745,19 @@
             </transformBlocks>
           </pipelineConfiguration>
           <analysisConfiguration>
-            <revapi.differences id="manually-vetted">
+            <revapi.differences id="manually-vetted ">
               <attachments>
                 <vetted>ok</vetted>
               </attachments>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <regex>true</regex>
+                  <code>java.annotation.removed</code>
+                  <annotation>@edu.umd.cs.findbugs.annotations.SuppressFBWarnings.*</annotation>
+                  <justification>SpotBugs Annotations are not relevant in API</justification>
+                </item>
+              </differences>
             </revapi.differences>
             <revapi.versions>
               <enabled>true</enabled>


### PR DESCRIPTION
It is save to remove or add these without changing the API.