### PR TITLE
Remove additional whitespace in RevApi ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -745,7 +745,7 @@
             </transformBlocks>
           </pipelineConfiguration>
           <analysisConfiguration>
-            <revapi.differences id="manually-vetted ">
+            <revapi.differences id="manually-vetted">
               <attachments>
                 <vetted>ok</vetted>
               </attachments>


### PR DESCRIPTION
This breaks the builds when no configuration is provided.