### PR TITLE
Inline version during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -989,6 +989,22 @@
               <skip>true</skip>
             </configuration>
           </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>versions-maven-plugin</artifactId>
+            <version>2.18.0</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>set</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <newVersion>${project.version}</newVersion>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Release https://github.com/jenkinsci/analysis-pom-plugin/releases/tag/10.2705.vd818c9b_9fe4e is still broken, it contains all properties, but the wrong version number.