### PR TITLE
Add a matrix build for Corretto JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [17, 21]
+        jdk: [17, 21, 25]
 
     runs-on: ${{ matrix.platform }}
     name: on ${{ matrix.platform }} with JDK ${{ matrix.jdk }}
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: '${{ matrix.jdk }}'
           check-latest: true
           cache: 'maven'


### PR DESCRIPTION
JDK 25 is only available on [Corretto](https://aws.amazon.com/corretto/) right now.