### PR TITLE
Bump Jenkins baseline to 2.516.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,10 @@
   </scm>
 
   <properties>
-    <revision>10</revision>
+    <revision>11</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/analysis-pom-plugin</gitHubRepo>
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.516</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <java.version>${maven.compiler.release}</java.version>
 
@@ -106,7 +106,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>5422.v0fce72a_b_b_8cf</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This will be the last plugin baseline with Java 17 support. 