### PR TITLE
Deactivate OSS-Index Analyzer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -937,6 +937,7 @@
               <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
               <format>JSON</format>
               <ossIndexAnalyzerEnabled>false</ossIndexAnalyzerEnabled>
+              <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
             </configuration>
             <executions>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -936,9 +936,7 @@
             <configuration>
               <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
               <format>JSON</format>
-              <ossIndexUsername>ullrich.hafner@gmail.com</ossIndexUsername>
-              <!--suppress UnresolvedMavenProperty: credentials are provided during CI -->
-              <ossIndexPassword>${env.OSS_INDEX_TOKEN}</ossIndexPassword>
+              <ossIndexAnalyzerEnabled>false</ossIndexAnalyzerEnabled>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
The OSS-Index Analyzer is now behind a paywall and requires a plan.